### PR TITLE
Fix for bands parsing edge case

### DIFF
--- a/app/src/androidTest/assets/bands_per_event_001.txt
+++ b/app/src/androidTest/assets/bands_per_event_001.txt
@@ -335,7 +335,7 @@ The Purple Ones
 Crywolf|Vallis Alps|Demo Taped
 Kimock
 Anderson East|Dylan LeBlanc
-Smokin' Ziggurats|Face Tat|Drkmtrls|Invisible Light Agency|at the Hemlock
+Smokin' Ziggurats|Face Tat|Drkmtrls|Invisible Light Agency
 Annie Girl & The Flight|The Cabin Project|Ruben Diaz
 Foreverland
 Nightwish
@@ -349,7 +349,7 @@ The Deathless|Gardens|Outdone|Morai|Give You Nothing
 Pam Tillis And Lorrie Morgan
 Dengue Fever
 The String Cheese Incident
-Mustache Harbor|The Jean Genies|Fleetwood Mask|at Bimbo's 365 Club
+Mustache Harbor|The Jean Genies|Fleetwood Mask
 Engelbert Humperdinck
 Angie Stone
 Adam Hirsch|Gabby Fluke-Moguf|TM Duplantis|Sam Genovese

--- a/app/src/main/java/com/dpalevich/thelist/utils/Parser.java
+++ b/app/src/main/java/com/dpalevich/thelist/utils/Parser.java
@@ -262,23 +262,32 @@ public class Parser {
                 inBrackets = false;
                 past_first_line |= isEOL;
                 if (isEOL && idx < length - 1) {
-                    if (event.regionMatches(idx, "\n       at ", 0, 11)) {
-                        return;
-                    }
-                    if (event.regionMatches(idx, "\n       a/a", 0, 11) || event.regionMatches(idx, "\n       21+", 0, 11)) {
-                        // Handle case like this:
-                        // mar 28 mon Underoath (Tampa, FL), Caspian at the Warfield, S.F.
-                        // a/a $28/$30 6:30pm/7:30pm # *** @ (was at Regency Ballroom)
-
-                        // recurse warning, the location was probably on the previous line and was
-                        // incorrectly interpreted as bands. Remove this line and do it again.
-
-                        // But only do this if previous line did not contain " at "
-                        int i = event.indexOf(" at ");
-                        if (i > 7 && i < idx) {
-                            event = event.substring(0, idx);
-                            getBands(event, date, bands);
+                    if (event.regionMatches(idx, "\n       ", 0, 8)) {
+                        idx += 8;
+                        while (' ' == event.charAt(idx)) {
+                            idx++;
+                            if (idx == length) {
+                                break;
+                            }
+                        }
+                        if (event.regionMatches(idx, "at ", 0, 3)) {
                             return;
+                        }
+                        if (event.regionMatches(idx, "a/a", 0, 3) || event.regionMatches(idx, "21+", 0, 3)) {
+                            // Handle case like this:
+                            // mar 28 mon Underoath (Tampa, FL), Caspian at the Warfield, S.F.
+                            // a/a $28/$30 6:30pm/7:30pm # *** @ (was at Regency Ballroom)
+
+                            // recurse warning, the location was probably on the previous line and was
+                            // incorrectly interpreted as bands. Remove this line and do it again.
+
+                            // But only do this if previous line did not contain " at "
+                            int i = event.indexOf(" at ");
+                            if (i > 7 && i < idx) {
+                                event = event.substring(0, idx);
+                                getBands(event, date, bands);
+                                return;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Addresses issue #15.

Fixes parsing of events when the last line starts with more spaces than
the normal 7 spaces.
