### PR TITLE
Fix edge case

### DIFF
--- a/app/src/androidTest/assets/bands_per_event_001.txt
+++ b/app/src/androidTest/assets/bands_per_event_001.txt
@@ -928,7 +928,7 @@ Dixie Chicks
 Dixie Chicks
 Babymetal
 Sting|Peter Gabriel
-Dragged Into Sunlight|Primitive Man|Cult Leader (Salt Lake City)
+Dragged Into Sunlight|Primitive Man|Cult Leader
 Darius Rucker|Dan + Shay|Michael Ray
 Twenty One Piolots
 Achilles Wheel|Grateful Bluegrass Boys

--- a/app/src/main/java/com/dpalevich/thelist/utils/Parser.java
+++ b/app/src/main/java/com/dpalevich/thelist/utils/Parser.java
@@ -255,6 +255,12 @@ public class Parser {
                 if (at_idx > 0 && -1 == event.indexOf(EOL, name_start_idx)) {
                     // TODO FIXME detect false positives of location
                     name = name.substring(0, at_idx);
+                    if (')' == name.charAt(at_idx - 1)) {
+                        int start_parenthesis = name.indexOf(" (");
+                        if (start_parenthesis > 0) {
+                            name = name.substring(0, start_parenthesis);
+                        }
+                    }
                     reachedLocation = true;
                 }
                 bands.add(name);


### PR DESCRIPTION
Addresses bug #19.

Fix edge case where parser fails to exclude  parenthisized text from a
parsed band name.
