### PR TITLE
Handle bad next line format edge case

### DIFF
--- a/app/src/androidTest/assets/bands_per_event_001.txt
+++ b/app/src/androidTest/assets/bands_per_event_001.txt
@@ -259,7 +259,7 @@ St. Lucia|Grace Mitchell
 Black Tiger Sex Machine|Apashe|Dabin
 Run River North|The Wild Reeds
 Penny & Sparrow|The Whistles & The Bells
-J Stalin|AKA Frank|Trill Youngins|Lil Yase|at Slim's
+J Stalin|AKA Frank|Trill Youngins|Lil Yase
 Kitten|Machineheart|Babe
 Viento Callejero|Candelaria
 Baths

--- a/app/src/main/java/com/dpalevich/thelist/utils/Parser.java
+++ b/app/src/main/java/com/dpalevich/thelist/utils/Parser.java
@@ -268,8 +268,8 @@ public class Parser {
                 inBrackets = false;
                 past_first_line |= isEOL;
                 if (isEOL && idx < length - 1) {
-                    if (event.regionMatches(idx, "\n       ", 0, 8)) {
-                        idx += 8;
+                    if (event.regionMatches(idx, "\n      ", 0, 7)) {
+                        idx += 7;
                         while (' ' == event.charAt(idx)) {
                             idx++;
                             if (idx == length) {


### PR DESCRIPTION
Addresses bug #24.

Handle the case where the next line starts with only 6 spaces instead of
the norma 7 spaces.
