### PR TITLE
Handling of hosts, and event statuses

### DIFF
--- a/app/src/androidTest/assets/bands_per_event_001.txt
+++ b/app/src/androidTest/assets/bands_per_event_001.txt
@@ -40,7 +40,7 @@ Fleshgod Apocalypse|Carach Angren|Abigail Williams|dj Rob Metal
 Seabound|Nite|Suicide Queen|dj Decay
 Americano Social Club
 Magic Trick|Grace Sings Sludge|The She's|Emotional
-Weed Plus Beer|Toyota|Miss Lightning|Jesus Dude Mom|Glndlfry|host Nicki Jizz
+Weed Plus Beer|Toyota|Miss Lightning|Jesus Dude Mom|Glndlfry|Nicki Jizz
 Striking Matches|Scott Mulvahill
 Desent Criminal|Signal Man|He Who Cannot Be Named|Screaming Minis
 Scarface
@@ -101,7 +101,7 @@ Betty's Love Child|Firewalkwithme
 Banana Gun
 Vokab Kompany
 King's X|Kings Of Spades
-cancelled:  R. City
+R. City
 La Noche Oskura|Matamoska|The Skunkadelics|Corazon Salvje|Runaway Planet
 Arrington de Dionyso|Dire Wolves
 Parquet Courts|Chris Cohen|Emotional|The World
@@ -143,7 +143,7 @@ Set Your Goals|The American Scene|Light Brigade
 Badr Vogu|Hallucinator|Leucrota|Pattern Breaker
 John Rybak + Friends
 Cayucas
-Jel|Bluezr|Mieksneak|NorthernDraw|Daoud|dj Mark Aubert|Muzae Sesay|host The Zap Tap & Joe Mousepad
+Jel|Bluezr|Mieksneak|NorthernDraw|Daoud|dj Mark Aubert|Muzae Sesay|The Zap Tap & Joe Mousepad
 Daley
 Kevin Seconds|Steve Soto|Russ Rankin
 Lake Street Dive|The Suffers
@@ -188,7 +188,7 @@ Diiv
 Sam Flax|Friendless Summer|Cole Lodge|Emotional
 dj Daniel Miller
 The Chieftins
-postponed:  Rihanna|Travis Scott|The Weeknd
+Rihanna|Travis Scott|The Weeknd
 Strawberry Girls|Covet|Belle Noire
 Megadeth|Suicidal Tendencies|Children Of Bodom|Havok
 Basia Bulat|The Weather Station
@@ -211,7 +211,7 @@ From Indian Lakes|Soren Bryce|Docks
 Wavves|Best Coast|Cherry Glazzer
 Gleen Huges|Joanne Shaw Taylor|Jared James Nichols
 Rebelution|Protoje
-cancelled:  Editors
+Editors
 Guantanamo Baywatch|The Gooch Palms|Meat Market
 Papadosio|Bluetech
 Charlie Puth|Phoebe Ryan|Sophie Beem
@@ -532,7 +532,7 @@ Rob Crow's Gloomy Place|Vertical Scratchers|Owl Paws
 Howardian|Golden Drugs|Teenage Chain
 Trecelence|Cataclysmic Assault|Discordia|The Royal Order|Abscission
 Yonder Mountain String Band|Polecat
-cancelled:  Complete|Octagrape|Aquarian Blood
+Complete|Octagrape|Aquarian Blood
 Weedeater|Author & Punisher|Today Is The Day|Lord Dying
 Trombone Shorty|Orleans Avenue
 Polica|Clara-Nova
@@ -917,9 +917,9 @@ Spraynard|Sundials|Jabber
 The Murderburgers|The Hot Toddies|The Atom Age
 Jeff Rosenstock|Antarctico Vespucci|Shinobu|Chotto Ghetto
 Janelle Monae
-The Trashwomen|Mummies|Real Kids|The Lyres|The Intelligence|Thee Oh Sees|Okmoniks|Angry Samoans|Amplified Heat|Psycotic Pineapple|Young Fresh Fellows|host John Waters
+The Trashwomen|Mummies|Real Kids|The Lyres|The Intelligence|Thee Oh Sees|Okmoniks|Angry Samoans|Amplified Heat|Psycotic Pineapple|Young Fresh Fellows|John Waters
 Broun Fellinis
-King Khan & The Shrines|Flamin' Groovies|Shannon & The Clams|Terry & Louie|Seth Bogart|The Spits|Buck Biloxi|Giorgio Murderer|Soda Boys|Death Valley Girls|The Dwarves|Fadeaways|host John Waters
+King Khan & The Shrines|Flamin' Groovies|Shannon & The Clams|Terry & Louie|Seth Bogart|The Spits|Buck Biloxi|Giorgio Murderer|Soda Boys|Death Valley Girls|The Dwarves|Fadeaways|John Waters
 Foreigner
 Rascal Flatts|Kelsea Ballerini|Chris Lane
 Brit Floyd

--- a/app/src/androidTest/java/com/dpalevich/thelist/utils/ParserTest.java
+++ b/app/src/androidTest/java/com/dpalevich/thelist/utils/ParserTest.java
@@ -136,6 +136,7 @@ public class ParserTest extends InstrumentationTestCase {
                 for (int i=0; i<info.eventCount; i++) {
                     try {
                         parser.getBands(parser.mEventList.get(info.firstEventIndex + i), info.dateString, bands);
+                        parser.fixupBands(bands);
                         sb.setLength(0);
                         for (String band : bands) {
                             sb.append(band);

--- a/app/src/main/java/com/dpalevich/thelist/model/EventMetadata.java
+++ b/app/src/main/java/com/dpalevich/thelist/model/EventMetadata.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 Daniel Palevich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dpalevich.thelist.model;
+
+import android.support.annotation.Nullable;
+
+/**
+ * Optional metadata for an event.
+ *
+ * Created by dpalevich on 3/6/16.
+ */
+public class EventMetadata {
+    public enum Status {
+        CANCELLED,
+        POSTPONED
+    }
+
+    public @Nullable Status status;
+}

--- a/app/src/main/java/com/dpalevich/thelist/utils/Parser.java
+++ b/app/src/main/java/com/dpalevich/thelist/utils/Parser.java
@@ -19,6 +19,7 @@ package com.dpalevich.thelist.utils;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import com.dpalevich.thelist.model.EventMetadata;
 import com.dpalevich.thelist.model.UniqueDateInfo;
 
 import java.text.ParseException;
@@ -333,5 +334,37 @@ public class Parser {
             }
             idx++;
         }
+    }
+
+    @VisibleForTesting
+    protected EventMetadata fixupBands(@NonNull ArrayList<String> bands) {
+        int count = bands.size();
+        String metaData = null;
+
+        EventMetadata.Status status = null;
+
+        for (int i=0; i<count; i++) {
+            String band = bands.get(i);
+            if(0 == i) {
+                if (band.regionMatches(0, "cancelled: ", 0, 11)) {
+                    status = EventMetadata.Status.CANCELLED;
+                } else if (band.regionMatches(0, "postponed: ", 0, 11)) {
+                    status = EventMetadata.Status.POSTPONED;
+                }
+                if (null != status) {
+                    band = band.substring(11).trim();
+                    bands.set(0, band);
+                }
+            }
+            if (band.regionMatches(0, "host ", 0, 5)) {
+                bands.set(i, band.substring(5).trim());
+            }
+        }
+        if (null != status) {
+            EventMetadata eventMetadata = new EventMetadata();
+            eventMetadata.status = status;
+            return eventMetadata;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Addresses issues #21 and #23.

Exclude 'host' prefix from band names. Exclude 'postponed:' and
'cancelled:' from band names, and save those event statuses in event
metadata.
